### PR TITLE
Should not apply random crop in test phase

### DIFF
--- a/test.py
+++ b/test.py
@@ -12,6 +12,7 @@ from util import html
 opt.nThreads = 1   # test code only supports nThreads=1
 opt.batchSize = 1  #test code only supports batchSize=1
 opt.serial_batches = True # no shuffle
+opt.loadSize = opt.fineSize  # test phase should not apply random crop
 
 data_loader = CreateDataLoader(opt)
 dataset = data_loader.load_data()


### PR DESCRIPTION
In the original implementation [phillipi/pix2pix](https://github.com/phillipi/pix2pix), the testing script shows that testing images should not be random cropped by default, which means `loadSize` is equal to `fineSize`.
(Ref: [test.lua L15-L16](https://github.com/phillipi/pix2pix/blob/master/test.lua#L15-L16))