### PR TITLE
Visdom port and display intermediate in single image pane

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -32,6 +32,8 @@ class BaseOptions():
         self.parser.add_argument('--serial_batches', action='store_true', help='if true, takes images in order to make batches, otherwise takes them randomly')
         self.parser.add_argument('--display_winsize', type=int, default=256,  help='display window size')
         self.parser.add_argument('--display_id', type=int, default=1, help='window id of the web display')
+        self.parser.add_argument('--display_port', type=int, default=8097, help='visdom port of the web display')
+        self.parser.add_argument('--display_single_pane_ncols', type=int, default=0, help='if positive, display all images in a single visdom web panel with certain number of images per row.')
         self.parser.add_argument('--identity', type=float, default=0.0, help='use identity mapping. Setting identity other than 1 has an effect of scaling the weight of the identity mapping loss. For example, if the weight of the identity loss should be 10 times smaller than the weight of the reconstruction loss, please set optidentity = 0.1')
         self.parser.add_argument('--use_dropout', action='store_true', help='use dropout for the generator')
         self.parser.add_argument('--max_dataset_size', type=int, default=float("inf"), help='Maximum number of samples allowed per dataset. If the dataset directory contains more than max_dataset_size, only a subset is loaded.')


### PR DESCRIPTION
Add options and functionalities for visdom port and display intermediate training results in single image pane.

Preview:
<img width="497" alt="screenshot 2017-06-21 22 25 35" src="https://user-images.githubusercontent.com/5674597/27416070-be071236-56d0-11e7-96d6-1691e2565a82.png">

Visdom image caption/title doesn't support multi-line strings. Labels are displayed in a separate text pane so that they can be in the same ordered grid as the images.