### PR TITLE
Fix max_dataset_size

### DIFF
--- a/data/custom_dataset_data_loader.py
+++ b/data/custom_dataset_data_loader.py
@@ -35,7 +35,13 @@ class CustomDatasetDataLoader(BaseDataLoader):
             num_workers=int(opt.nThreads))
 
     def load_data(self):
-        return self.dataloader
+        return self
 
     def __len__(self):
         return min(len(self.dataset), self.opt.max_dataset_size)
+
+    def __iter__(self):
+        for i, data in enumerate(self.dataloader):
+            if i >= self.opt.max_dataset_size:
+                break
+            yield data


### PR DESCRIPTION
Current `max_dataset_size` has no use except printing because `BaseDataLoader.__len__` isn't really used in training/testing. This PR fixes the option.