### PR TITLE
Should normalize input and truth images separately

### DIFF
--- a/data/aligned_dataset.py
+++ b/data/aligned_dataset.py
@@ -27,7 +27,7 @@ class AlignedDataset(BaseDataset):
         AB_path = self.AB_paths[index]
         AB = Image.open(AB_path).convert('RGB')
         AB = AB.resize((self.opt.loadSize * 2, self.opt.loadSize), Image.BICUBIC)
-        AB = self.transform(AB)
+        AB = transforms.ToTensor()(AB)
 
         w_total = AB.size(2)
         w = int(w_total / 2)
@@ -39,6 +39,9 @@ class AlignedDataset(BaseDataset):
                w_offset:w_offset + self.opt.fineSize]
         B = AB[:, h_offset:h_offset + self.opt.fineSize,
                w + w_offset:w + w_offset + self.opt.fineSize]
+
+        A = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))(A)
+        B = transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))(B)
 
         if self.opt.which_direction == 'BtoA':
             input_nc = self.opt.output_nc


### PR DESCRIPTION
This is important to train the generator with input images that are normalized without the truth such that when the model is used in test time and the truth is not available, the input will be normalized similarly as during training. 