### PR TITLE
Variable -> Numpy error in tensor2im()

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -27,7 +27,7 @@ def tensor2im(input_image, imtype=np.uint8):
         image_tensor = input_image.data
     else:
         return input_image
-    image_numpy = image_tensor[0].cpu().float().numpy()
+    image_numpy = image_tensor[0].cpu().float().data.numpy()
     if image_numpy.shape[0] == 1:
         image_numpy = np.tile(image_numpy, (3, 1, 1))
     image_numpy = (np.transpose(image_numpy, (1, 2, 0)) + 1) / 2.0 * 255.0


### PR DESCRIPTION

Issue with explicitly converting torch.autograd.Variable into numpy array in utils.tensor2im(). Tensor needs to be retrieved from Variable by calling Variable.data.