### PR TITLE
Update cycle_gan_model.py

### DIFF
--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -27,8 +27,8 @@ class CycleGANModel(BaseModel):
         # specify the training losses you want to print out. The program will call base_model.get_current_losses
         self.loss_names = ['D_A', 'G_A', 'cycle_A', 'idt_A', 'D_B', 'G_B', 'cycle_B', 'idt_B']
         # specify the images you want to save/display. The program will call base_model.get_current_visuals
-        visual_names_A = ['real_A', 'fake_B', 'rec_A']
-        visual_names_B = ['real_B', 'fake_A', 'rec_B']
+        visual_names_A = ['real_A', 'fake_A', 'rec_A']
+        visual_names_B = ['real_B', 'fake_B', 'rec_B']
         if self.isTrain and self.opt.lambda_identity > 0.0:
             visual_names_A.append('idt_A')
             visual_names_B.append('idt_B')


### PR DESCRIPTION
Dear Sir

In line 30 and 31, there are might be typos with naming: 'fake_A' and 'fake_B'. I have changed places with incorrect ones.  Initially, in line 30 it was visual_names_A = ['real_A', 'fake_B, 'rec_A'] <-- Here I suppose fake_B should be fake_A, no? The same in line 31 but in opposite way.

Thanks

Kind regards
Altynay