### PR TITLE
Removed unneeded `self.input` attribute

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -29,7 +29,7 @@ class BaseModel():
         self.image_paths = []
 
     def set_input(self, input):
-        self.input = input
+        pass
 
     def forward(self):
         pass


### PR DESCRIPTION
After some work of understanding your nice model implementation, I just wanted to start my contribution by removing this unneeded assignment as the attribute `self.input` is never used.  

First of all, thank you a lot for open-sourcing your model implementation. If every scientific author did that the world would be a better place.
However, I have a small request. When you and other parties make further developing on this codebase, would you please enforce the use of docstrings, for instance, [numpydoc docstring](https://docs.scipy.org/doc/numpy-1.15.0/docs/howto_document.html). That would make it much easier for new parties, like my self, to understand the code, such that we all can fix potential bugs and expand the codebase.

Regards Peter Fogh