### PR TITLE
Update networks.py

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -342,12 +342,12 @@ class NLayerDiscriminator(nn.Module):
         nf_mult = min(2**n_layers, 8)
         sequence += [
             nn.Conv2d(ndf * nf_mult_prev, ndf * nf_mult,
-                      kernel_size=kw, stride=1, padding=padw, bias=use_bias),
+                      kernel_size=kw, stride=2, padding=padw, bias=use_bias),
             norm_layer(ndf * nf_mult),
             nn.LeakyReLU(0.2, True)
         ]
 
-        sequence += [nn.Conv2d(ndf * nf_mult, 1, kernel_size=kw, stride=1, padding=padw)]
+        sequence += [nn.Conv2d(ndf * nf_mult, 1, kernel_size=kw, stride=0, padding=padw)]
 
         if use_sigmoid:
             sequence += [nn.Sigmoid()]


### PR DESCRIPTION
Last Conv layer needs to have a stride of 2, just like in the article to keep the down-sampling factor as 2.
For the 70x70 PatchGAN, the last conv layer that brings the tensor to an Nx1x1x1 needs a kernel size of 4, a stride of 1 and no padding.
With padding, the output tensor is of shape Nx1x3x3 instead of Nx1x1x1 (for a 70x70 input).