### PR TITLE
Fix incorrect commandline argument

### DIFF
--- a/docs/qa.md
+++ b/docs/qa.md
@@ -22,7 +22,7 @@ torch.cuda.init()
 print(torch.randn(1, device='cuda')
 ```
 
-If you met an error, it is likely that your PyTorch build does not work with CUDA, e.g., it is installl from the official MacOS binary, or you have a GPU that is too old and not supported anymore. You may run the the code with CPU using `--device_ids -1`.
+If you met an error, it is likely that your PyTorch build does not work with CUDA, e.g., it is installl from the official MacOS binary, or you have a GPU that is too old and not supported anymore. You may run the the code with CPU using `--gpu_ids -1`.
 
 #### TypeError: Object of type 'Tensor' is not JSON serializable ([#258](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/258))
 Similar errors: AttributeError: module 'torch' has no attribute 'device' ([#314](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/issues/314))


### PR DESCRIPTION
The way to run in cpu mode is with --gpu_ids -1. Likely it was changed at some point and the docs need to be updated to reflect that change. --device_ids -1 isn't accepted as a commanline argument to python train.py.

Apologies if the --device_ids -1 is a correct commandline argument to a different .py file!