### PR TITLE
remove Non-ASCII character '\xef'

### DIFF
--- a/options/train_options.py
+++ b/options/train_options.py
@@ -31,7 +31,7 @@ class TrainOptions(BaseOptions):
         parser.add_argument('--niter_decay', type=int, default=100, help='# of iter to linearly decay learning rate to zero')
         parser.add_argument('--beta1', type=float, default=0.5, help='momentum term of adam')
         parser.add_argument('--lr', type=float, default=0.0002, help='initial learning rate for adam')
-        parser.add_argument('--gan_mode', type=str, default='lsgan', help='the type of GAN objective. [vanilla| lsgan ｜ wgangp]. vanilla GAN loss is the cross-entropy objective used in the original GAN paper.')
+        parser.add_argument('--gan_mode', type=str, default='lsgan', help='the type of GAN objective. [vanilla| lsgan | wgangp]. vanilla GAN loss is the cross-entropy objective used in the original GAN paper.')
         parser.add_argument('--pool_size', type=int, default=50, help='the size of image buffer that stores previously generated images')
         parser.add_argument('--lr_policy', type=str, default='linear', help='learning rate policy. [linear | step | plateau | cosine]')
         parser.add_argument('--lr_decay_iters', type=int, default=50, help='multiply by a gamma every lr_decay_iters iterations')


### PR DESCRIPTION
`SyntaxError: Non-ASCII character '\xef' in file /data/pytorch-CycleGAN-and-pix2pix/options/train_options.py on line 34, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details`

encountered this error when going through the steps to get started. Just a minor fix