### PR TITLE
changes deprecated cv2.imread flag in combine_A_and_B

### DIFF
--- a/datasets/combine_A_and_B.py
+++ b/datasets/combine_A_and_B.py
@@ -42,7 +42,7 @@ for sp in splits:
             if args.use_AB:
                 name_AB = name_AB.replace('_A.', '.')  # remove _A
             path_AB = os.path.join(img_fold_AB, name_AB)
-            im_A = cv2.imread(path_A, cv2.CV_LOAD_IMAGE_COLOR)
-            im_B = cv2.imread(path_B, cv2.CV_LOAD_IMAGE_COLOR)
+            im_A = cv2.imread(path_A, cv2.IMREAD_COLOR
+            im_B = cv2.imread(path_B, cv2.IMREAD_COLOR)
             im_AB = np.concatenate([im_A, im_B], 1)
             cv2.imwrite(path_AB, im_AB)


### PR DESCRIPTION
cv2 3.0 and newer no longer use the CV2_LOAD_IMAGE_COLOR flag

I made this change after reading this stackoverflow question https://stackoverflow.com/questions/19013961/cv2-imread-flags-not-found

running this in a python3.5 virtualenv with opencv-python 4.0.0 works correctly.