### PR TITLE
Update combine_A_and_B.py

### DIFF
--- a/datasets/combine_A_and_B.py
+++ b/datasets/combine_A_and_B.py
@@ -42,7 +42,7 @@ for sp in splits:
             if args.use_AB:
                 name_AB = name_AB.replace('_A.', '.')  # remove _A
             path_AB = os.path.join(img_fold_AB, name_AB)
-            im_A = cv2.imread(path_A, cv2.CV_LOAD_IMAGE_COLOR)
-            im_B = cv2.imread(path_B, cv2.CV_LOAD_IMAGE_COLOR)
+            im_A = cv2.imread(path_A, cv2.IMREAD_COLOR)
+            im_B = cv2.imread(path_B, cv2.IMREAD_COLOR)
             im_AB = np.concatenate([im_A, im_B], 1)
             cv2.imwrite(path_AB, im_AB)


### PR DESCRIPTION
For new version of OpenCV, original version of `cv2.imread(path_A, cv2.CV_LOAD_IMAGE_COLOR)` works no more and only throws you an error `AttributeError: module 'cv2.cv2' has no attribute 'CV_LOAD_IMAGE_COLOR'`. The right way to fix is to change this to `IMREAD_COLOR`.
Tested on OpenCV` '3.4.3'`.