### PR TITLE
separate save train and test options

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -105,7 +105,7 @@ class BaseOptions():
         # save to the disk
         expr_dir = os.path.join(opt.checkpoints_dir, opt.name)
         util.mkdirs(expr_dir)
-        file_name = os.path.join(expr_dir, 'opt.txt')
+        file_name = os.path.join(expr_dir, '{}_opt.txt'.format(opt.phase))
         with open(file_name, 'wt') as opt_file:
             opt_file.write(message)
             opt_file.write('\n')


### PR DESCRIPTION
I think it is usefull to save training and test options in different files. Now we rewrite training options when we run test script. And after that it is hard to restore all training options.