### PR TITLE
Update q and a

### DIFF
--- a/docs/qa.md
+++ b/docs/qa.md
@@ -45,7 +45,7 @@ Many GAN losses do not converge (exception: WGAN, WGAN-GP, etc. ) due to the nat
 The current code only supports RGB and grayscale images. If you would like to train the model on other data types, please follow the following steps:
 
 - change the parameters `--input_nc` and `--output_nc` to the number of channels in your input/output images.
-- Write your own custom data loader (It is easy as long as you know how to load your data with python). If you write a new data loader class, you need to change the flag `--dataset_mode` accordingly. Alternatively, you can modify the existing data loader. For aligned datasets, change this [line](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/data/aligned_dataset.py#L24); For unaligned datasets, change these two [lines](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/data/unaligned_dataset.py#L36).
+- Write your own custom data loader (It is easy as long as you know how to load your data with python). If you write a new data loader class, you need to change the flag `--dataset_mode` accordingly. Alternatively, you can modify the existing data loader. For aligned datasets, change this [line](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/data/aligned_dataset.py#L41); For unaligned datasets, change these two [lines](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/data/unaligned_dataset.py#L57).
 
 - If you use visdom and HTML to visualize the results, you may also need to change the visualization code.
 


### PR DESCRIPTION
These files I corrected were changed since the commit 568ad02a.
To avoid obsoletion and misleading, it might be a good idea to change linked URLs from `master` to specific commit.
Like `https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/tree/22fe4465c120ac92a2de09c3c2d50cbbe0e63f29/data/aligned_dataset.py#L41`