### PR TITLE
Changing import os.path to import os

### DIFF
--- a/data/aligned_dataset.py
+++ b/data/aligned_dataset.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 from data.base_dataset import BaseDataset, get_params, get_transform
 from data.image_folder import make_dataset
 from PIL import Image

--- a/data/colorization_dataset.py
+++ b/data/colorization_dataset.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 from data.base_dataset import BaseDataset, get_transform
 from data.image_folder import make_dataset
 from skimage import color  # require skimage

--- a/data/image_folder.py
+++ b/data/image_folder.py
@@ -8,7 +8,6 @@ import torch.utils.data as data
 
 from PIL import Image
 import os
-import os.path
 
 IMG_EXTENSIONS = [
     '.jpg', '.JPG', '.jpeg', '.JPEG',

--- a/data/unaligned_dataset.py
+++ b/data/unaligned_dataset.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 from data.base_dataset import BaseDataset, get_transform
 from data.image_folder import make_dataset
 from PIL import Image


### PR DESCRIPTION
Importing both `os` and `os.path` is redundant since importing `os` will import `os.path` and importing `os.path` will also import the `os` package. So it's more clean and explicit to simply `import os` because that reflects better on what the import is actually doing.

Reference: https://www.mail-archive.com/python-list@python.org/msg188236.html