### PR TITLE
minor mistakes/typos

### DIFF
--- a/CycleGAN.ipynb
+++ b/CycleGAN.ipynb
@@ -96,7 +96,7 @@
         "\n",
         "Download one of the official datasets with:\n",
         "\n",
-        "-   `bash ./datasets/download_cyclegan_dataset.sh [apple2orange, orange2apple, summer2winter_yosemite, winter2summer_yosemite, horse2zebra, zebra2horse, monet2photo, style_monet, style_cezanne, style_ukiyoe, style_vangogh, sat2map, map2sat, cityscapes_photo2label, cityscapes_label2photo, facades_photo2label, facades_label2photo, iphone2dslr_flower]`\n",
+        "-   `bash ./datasets/download_cyclegan_dataset.sh [apple2orange, summer2winter_yosemite, horse2zebra, monet2photo, cezanne2photo, ukiyoe2photo, vangogh2photo, maps, cityscapes, facades, iphone2dslr_flower, ae_photos]`\n",
         "\n",
         "Or use your own dataset by creating the appropriate folders and adding in the images.\n",
         "\n",

--- a/datasets/prepare_cityscapes_dataset.py
+++ b/datasets/prepare_cityscapes_dataset.py
@@ -11,7 +11,7 @@ The processed images will be placed at --output_dir.
 
 Example usage:
 
-python prepare_cityscapes_dataset.py --gitFine_dir ./gtFine/ --leftImg8bit_dir ./leftImg8bit --output_dir ./datasets/cityscapes/
+python prepare_cityscapes_dataset.py --gtFine_dir ./gtFine/ --leftImg8bit_dir ./leftImg8bit --output_dir ./datasets/cityscapes/
 """
 
 def load_resized_img(path):

--- a/scripts/eval_cityscapes/evaluate.py
+++ b/scripts/eval_cityscapes/evaluate.py
@@ -43,7 +43,7 @@ def main():
         label = CS.load_label(args.split, city, idx)
         im_file = args.result_dir + '/' + idx + '_leftImg8bit.png'
         im = np.array(Image.open(im_file))
-        im = scipy.misc.imresize(im, (label.shape[1], label.shape[2]))
+        im = np.array(Image.fromarray(im).resize((label.shape[1], label.shape[2])))
         out = segrun(net, CS.preprocess(im))
         hist_perframe += fast_hist(label.flatten(), out.flatten(), n_cl)
         if args.save_output_images > 0:


### PR DESCRIPTION
- correct download dataset list in CycleGAN.ipynb
- typo of gtFine_dir in example usage in cityscapes evaluation
- scipy.misc.imresize is deprecated in cityscapes evaluation