### PR TITLE
conda no longer comes with pip, need to install it explicitly

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - python=3.6
 - pytorch=1.4.0
 - scipy
+- pip
 - pip:
   - dominate==2.4.0
   - torchvision==0.5.0


### PR DESCRIPTION
Prevents getting spammed with a wall of `Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
` .
