### PR TITLE
change image.bicubic to transformer bicubic to avoid output warning

### DIFF
--- a/data/base_dataset.py
+++ b/data/base_dataset.py
@@ -78,7 +78,7 @@ def get_params(opt, size):
     return {'crop_pos': (x, y), 'flip': flip}
 
 
-def get_transform(opt, params=None, grayscale=False, method=Image.BICUBIC, convert=True):
+def get_transform(opt, params=None, grayscale=False, method=transforms.InterpolationMode.BICUBIC, convert=True):
     transform_list = []
     if grayscale:
         transform_list.append(transforms.Grayscale(1))
@@ -112,7 +112,7 @@ def get_transform(opt, params=None, grayscale=False, method=Image.BICUBIC, conve
     return transforms.Compose(transform_list)
 
 
-def __make_power_2(img, base, method=Image.BICUBIC):
+def __make_power_2(img, base, method=transforms.InterpolationMode.BICUBIC):
     ow, oh = img.size
     h = int(round(oh / base) * base)
     w = int(round(ow / base) * base)
@@ -123,7 +123,7 @@ def __make_power_2(img, base, method=Image.BICUBIC):
     return img.resize((w, h), method)
 
 
-def __scale_width(img, target_size, crop_size, method=Image.BICUBIC):
+def __scale_width(img, target_size, crop_size, method=transforms.InterpolationMode.BICUBIC):
     ow, oh = img.size
     if ow == target_size and oh >= crop_size:
         return img


### PR DESCRIPTION
The original code will frequently output an annoying warning message: `UserWarning: Argument interpolation should be of type InterpolationMode instead of int. Please, use InterpolationMode enum. `