### PR TITLE
Fix DDP normalization type check logic

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -114,9 +114,9 @@ class BaseModel(ABC):
 
                 # Wrap networks with DDP after loading
                 if dist.is_initialized():
-                    # Check if using syncbatch normalization for DDP
-                    if self.opt.norm == "syncbatch":
-                        raise ValueError(f"For distributed training, opt.norm must be 'syncbatch' or 'inst', but got '{self.opt.norm}'. " "Please set --norm syncbatch for multi-GPU training.")
+                    # Check if using syncbatch or instance normalization for DDP
+                    if self.opt.norm != "syncbatch" and self.opt.norm != "instance":
+                        raise ValueError(f"For distributed training, opt.norm must be 'syncbatch' or 'instance', but got '{self.opt.norm}'. " "Please set --norm syncbatch for multi-GPU training.")
 
                     net = torch.nn.parallel.DistributedDataParallel(net, device_ids=[self.device.index])
                     # Sync all processes after DDP wrapping


### PR DESCRIPTION
## Summary
- Fix inverted condition in DDP normalization check
- Correct 'inst' to 'instance' in error message

## Problem
The current code raises an error when `norm == 'syncbatch'`:
```python
if self.opt.norm == "syncbatch":
    raise ValueError(...)
```

This is the opposite of the intended behavior. The code should raise an error when `norm` is **NOT** 'syncbatch' or 'instance'.

## Solution
Changed the condition to:
```python
if self.opt.norm != "syncbatch" and self.opt.norm != "instance":
    raise ValueError(...)
```

Also fixed the error message to reference 'instance' instead of 'inst' for clarity.

## Test plan
- [ ] Run DDP training with `--norm syncbatch`
- [ ] Run DDP training with `--norm instance`
- [ ] Verify error is raised for other norm types (e.g., 'batch')

Fixes #1709